### PR TITLE
Add possibility to suppress stacktrace of @assert

### DIFF
--- a/src/RelevanceStacktrace.jl
+++ b/src/RelevanceStacktrace.jl
@@ -130,6 +130,7 @@ assert_no_stacktrace(ex_val, msgs...) = begin
   @assert ex_val msgs...
   enable_next_stacktrace_print()
 end
+export @assert_no_stacktrace, assert_no_stacktrace
 macro assert_no_stacktrace(ex, msgs...)
   return :(assert_no_stacktrace($(esc(ex)), $msgs))
 end

--- a/src/RelevanceStacktrace.jl
+++ b/src/RelevanceStacktrace.jl
@@ -84,12 +84,19 @@ end
 
 Base.show_full_backtrace(io::IO, trace::Vector; print_linebreaks::Bool) = show_full_backtrace_relevance(io, trace, print_linebreaks)
 function show_full_backtrace_relevance(io::IO, trace, print_linebreaks::Bool)
+  global is_next_stacktrace_disabled
   num_frames = length(trace)
   ndigits_max = ndigits(num_frames)
   
   modulecolordict = copy(Base.STACKTRACE_FIXEDCOLORS)
   ownmodulescounter = IdDict()
   
+  if is_next_stacktrace_disabled
+    is_next_stacktrace_disabled = false
+    println(io, "\nStacktrace was disabled.")
+    return
+  end
+
   println(io, "\nStacktrace:")
 
   try
@@ -118,6 +125,22 @@ function show_full_backtrace_relevance(io::IO, trace, print_linebreaks::Bool)
     end
   end
 end
-
+assert_no_stacktrace(ex_val, msgs...) = begin
+  disable_next_stacktrace_print()
+  @assert ex_val msgs...
+  enable_next_stacktrace_print()
+end
+macro assert_no_stacktrace(ex, msgs...)
+  return :(assert_no_stacktrace($(esc(ex)), $msgs))
+end
+is_next_stacktrace_disabled = false
+disable_next_stacktrace_print() = begin
+  global is_next_stacktrace_disabled
+  is_next_stacktrace_disabled = true
+end
+enable_next_stacktrace_print() = begin
+  global is_next_stacktrace_disabled
+  is_next_stacktrace_disabled = false
+end
 
 end # module

--- a/test/RelevanceStacktrace.test.jl
+++ b/test/RelevanceStacktrace.test.jl
@@ -82,8 +82,7 @@ func1(3)
 
 #%%
 using Revise
-using RelevanceStacktrace: @assert_no_stacktrace
-using RelevanceStacktrace: assert_no_stacktrace
+using RelevanceStacktrace
 @show "OK"
 assert_no_stacktrace(true,)
 @assert_no_stacktrace false "OKAY"

--- a/test/RelevanceStacktrace.test.jl
+++ b/test/RelevanceStacktrace.test.jl
@@ -80,3 +80,10 @@ func4(x) = x.+ @assert false
 
 func1(3)
 
+#%%
+using Revise
+using RelevanceStacktrace: @assert_no_stacktrace
+using RelevanceStacktrace: assert_no_stacktrace
+@show "OK"
+assert_no_stacktrace(true,)
+@assert_no_stacktrace false "OKAY"


### PR DESCRIPTION
Less logs to have asserts with no stacktrace. Less scrolling is needed to find your code if the @assert was intentional. 
There is a note if stacktrace was suppressed for safety reasons.